### PR TITLE
tagName을 기반으로 tag를 검색하는 기능 추가

### DIFF
--- a/docs/tify-api.md
+++ b/docs/tify-api.md
@@ -5,6 +5,8 @@ TIFY(This is for you) API
 - GET /posts : 모든 페이지 목록
 - GET /posts/{postId} : 특정 페이지 조회
 - POST /posts : 페이지 생성
+- GET /posts/{postId}/tags : 페이지의 태그 조회
+- POST /posts/{postId}/tags : 페이지에 태그 추가
 
 ## RECEIVER
 - GET /receivers/{receiverId} : 특정 생일자 조회

--- a/src/main/java/com/depromeet/tifyapi/Exception/BadRequestException.java
+++ b/src/main/java/com/depromeet/tifyapi/Exception/BadRequestException.java
@@ -1,0 +1,4 @@
+package com.depromeet.tifyapi.Exception;
+
+public class BadRequestException extends RuntimeException {
+}

--- a/src/main/java/com/depromeet/tifyapi/controller/PostController.java
+++ b/src/main/java/com/depromeet/tifyapi/controller/PostController.java
@@ -2,8 +2,11 @@ package com.depromeet.tifyapi.controller;
 
 import com.depromeet.tifyapi.Exception.NoContentException;
 import com.depromeet.tifyapi.dto.PostDto;
+import com.depromeet.tifyapi.dto.TagDto;
 import com.depromeet.tifyapi.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,5 +31,17 @@ public class PostController {
     @PostMapping
     public int addPost(@RequestBody PostDto postDto) {
         return postService.createPost(postDto);
+    }
+
+    @PostMapping("/{postId:\\d+}/tags")
+    public ResponseEntity<String> addTagToPost(@PathVariable("postId") Integer postId,
+                                               @RequestParam String tagName) {
+        postService.addTagToPost(postId, tagName);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{postId:\\d+}/tags")
+    public List<TagDto> getTagsInPost(@PathVariable("postId") Integer postId) {
+        return postService.getTagsInPost(postId);
     }
 }

--- a/src/main/java/com/depromeet/tifyapi/controller/ReceiverController.java
+++ b/src/main/java/com/depromeet/tifyapi/controller/ReceiverController.java
@@ -2,7 +2,6 @@ package com.depromeet.tifyapi.controller;
 
 import com.depromeet.tifyapi.Exception.NoContentException;
 import com.depromeet.tifyapi.dto.ReceiverDto;
-import com.depromeet.tifyapi.model.Receiver;
 import com.depromeet.tifyapi.service.ReceiverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/depromeet/tifyapi/controller/TagController.java
+++ b/src/main/java/com/depromeet/tifyapi/controller/TagController.java
@@ -4,8 +4,10 @@ import com.depromeet.tifyapi.Exception.NoContentException;
 import com.depromeet.tifyapi.dto.TagDto;
 import com.depromeet.tifyapi.service.TagService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -15,8 +17,21 @@ public class TagController {
     private TagService tagService;
 
     @GetMapping
-    public List<TagDto> getTags() {
-        return tagService.getTags();
+    public List<TagDto> getTags(@RequestParam(value = "name", required = false, defaultValue = "") String name,
+                                @RequestParam(value = "type", required = false, defaultValue = "equal") String type) {
+        if (StringUtils.isEmpty(name)) {
+            return tagService.getTags();
+        }
+
+        if ("equal".equals(type)) {
+            return tagService.getTagByName(name)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+        } else if ("include".equals(type)) {
+            return tagService.getTagsIncludingName(name);
+        } else {
+            throw new NoContentException();
+        }
     }
 
     @GetMapping("/{tagId:\\d+}")

--- a/src/main/java/com/depromeet/tifyapi/dto/PresentDto.java
+++ b/src/main/java/com/depromeet/tifyapi/dto/PresentDto.java
@@ -38,7 +38,7 @@ public class PresentDto {
                 .build();
     }
 
-    public static PresentDto from(Present present) {
+    public static PresentDto of(Present present) {
         return PresentDto.builder()
                 .presentId(present.getPresentId())
                 .name(present.getName())

--- a/src/main/java/com/depromeet/tifyapi/dto/TagDto.java
+++ b/src/main/java/com/depromeet/tifyapi/dto/TagDto.java
@@ -16,4 +16,11 @@ public class TagDto {
                 .name(name)
                 .build();
     }
+
+    public static TagDto of(Tag tag) {
+        return TagDto.builder()
+                .tagId(tag.getTagId())
+                .name(tag.getName())
+                .build();
+    }
 }

--- a/src/main/java/com/depromeet/tifyapi/dto/TagDto.java
+++ b/src/main/java/com/depromeet/tifyapi/dto/TagDto.java
@@ -1,11 +1,15 @@
 package com.depromeet.tifyapi.dto;
 
 import com.depromeet.tifyapi.model.Tag;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class TagDto {
     private Integer tagId;
     private String name;

--- a/src/main/java/com/depromeet/tifyapi/mapper/DescriptionMapper.java
+++ b/src/main/java/com/depromeet/tifyapi/mapper/DescriptionMapper.java
@@ -1,0 +1,10 @@
+package com.depromeet.tifyapi.mapper;
+
+import com.depromeet.tifyapi.model.Description;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface DescriptionMapper {
+    Integer createDescription(@Param("description") Description description);
+}

--- a/src/main/java/com/depromeet/tifyapi/mapper/TagMapper.java
+++ b/src/main/java/com/depromeet/tifyapi/mapper/TagMapper.java
@@ -12,4 +12,6 @@ public interface TagMapper {
     Tag findOne(@Param("tagId") Integer tagId);
     Integer createTag(@Param("tag") Tag tag);
     List<Tag> findTagsByPostId(@Param("postId") Integer postId);
+    Tag findTagByName(@Param("name") String name);
+    List<Tag> findTagsIncludingName(@Param("name") String name);
 }

--- a/src/main/java/com/depromeet/tifyapi/model/Description.java
+++ b/src/main/java/com/depromeet/tifyapi/model/Description.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class Description {
-    Integer descriptionId;
-    Integer postId;
-    Integer tagId;
+    private Integer descriptionId;
+    private Integer postId;
+    private Integer tagId;
 }

--- a/src/main/java/com/depromeet/tifyapi/model/Description.java
+++ b/src/main/java/com/depromeet/tifyapi/model/Description.java
@@ -1,0 +1,12 @@
+package com.depromeet.tifyapi.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Description {
+    Integer descriptionId;
+    Integer postId;
+    Integer tagId;
+}

--- a/src/main/java/com/depromeet/tifyapi/model/Tag.java
+++ b/src/main/java/com/depromeet/tifyapi/model/Tag.java
@@ -9,11 +9,4 @@ import lombok.Getter;
 public class Tag {
     private Integer tagId;
     private String name;
-
-    public TagDto toTagDto() {
-        return TagDto.builder()
-                .tagId(tagId)
-                .name(name)
-                .build();
-    }
 }

--- a/src/main/java/com/depromeet/tifyapi/service/PostService.java
+++ b/src/main/java/com/depromeet/tifyapi/service/PostService.java
@@ -1,6 +1,7 @@
 package com.depromeet.tifyapi.service;
 
 import com.depromeet.tifyapi.dto.PostDto;
+import com.depromeet.tifyapi.dto.TagDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,6 @@ public interface PostService {
     Optional<PostDto> getPost(Integer postId);
     List<PostDto> getPosts();
     Integer createPost(PostDto postDto);
+    Integer addTagToPost(Integer postId, String tagName);
+    List<TagDto> getTagsInPost(Integer postId);
 }

--- a/src/main/java/com/depromeet/tifyapi/service/PostServiceImpl.java
+++ b/src/main/java/com/depromeet/tifyapi/service/PostServiceImpl.java
@@ -62,9 +62,13 @@ public class PostServiceImpl implements PostService {
             throw new BadRequestException();
         }
 
+        if (postMapper.findOne(postId) == null) {
+            throw new BadRequestException();
+        }
+
         TagDto tagDto = Optional.ofNullable(tagMapper.findTagByName(tagName))
                 .map(TagDto::of)
-                .orElseThrow(() -> new NoContentException());
+                .orElseThrow(() -> new BadRequestException());
 
         Description description = Description.builder()
                 .postId(postId)

--- a/src/main/java/com/depromeet/tifyapi/service/PostServiceImpl.java
+++ b/src/main/java/com/depromeet/tifyapi/service/PostServiceImpl.java
@@ -1,11 +1,20 @@
 package com.depromeet.tifyapi.service;
 
+import com.depromeet.tifyapi.Exception.BadRequestException;
 import com.depromeet.tifyapi.Exception.NoContentException;
 import com.depromeet.tifyapi.dto.PostDto;
+import com.depromeet.tifyapi.dto.TagDto;
+import com.depromeet.tifyapi.mapper.DescriptionMapper;
 import com.depromeet.tifyapi.mapper.PostMapper;
+import com.depromeet.tifyapi.mapper.TagMapper;
+import com.depromeet.tifyapi.model.Description;
 import com.depromeet.tifyapi.model.Post;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,9 +22,14 @@ import java.util.stream.Collectors;
 import java.util.Optional;
 
 @Service
+@Slf4j
 public class PostServiceImpl implements PostService {
     @Autowired
     private PostMapper postMapper;
+    @Autowired
+    private TagMapper tagMapper;
+    @Autowired
+    private DescriptionMapper descriptionMapper;
 
     @Override
     public Optional<PostDto> getPost(Integer postId) {
@@ -39,6 +53,40 @@ public class PostServiceImpl implements PostService {
             throw new NoContentException();
         }
         return post.getPostId();
+    }
+
+    @Override
+    @Transactional
+    public Integer addTagToPost(Integer postId, String tagName) {
+        if (StringUtils.isEmpty(tagName)) {
+            throw new BadRequestException();
+        }
+
+        TagDto tagDto = Optional.ofNullable(tagMapper.findTagByName(tagName))
+                .map(TagDto::of)
+                .orElseThrow(() -> new NoContentException());
+
+        Description description = Description.builder()
+                .postId(postId)
+                .tagId(tagDto.getTagId())
+                .build();
+
+        try {
+            descriptionMapper.createDescription(description);
+        } catch (DuplicateKeyException e) {
+            log.trace("DuplicateKey : postId={}, tagId={}", description.getPostId(), description.getTagId());
+        } finally {
+            return 1;
+        }
+    }
+
+    @Override
+    public List<TagDto> getTagsInPost(Integer postId) {
+        return Optional.ofNullable(tagMapper.findTagsByPostId(postId))
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(TagDto::of)
+                .collect(Collectors.toList());
     }
 
 //    @Override

--- a/src/main/java/com/depromeet/tifyapi/service/PresentServiceImpl.java
+++ b/src/main/java/com/depromeet/tifyapi/service/PresentServiceImpl.java
@@ -28,7 +28,7 @@ public class PresentServiceImpl implements PresentService {
     @Override
     public Optional<PresentDto> getPresent(Integer presentId) {
         return Optional.ofNullable(presentMapper.findOne(presentId))
-                .map(PresentDto::from);
+                .map(PresentDto::of);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class PresentServiceImpl implements PresentService {
         return Optional.ofNullable(presentMapper.findAll())
                 .orElse(Collections.emptyList())
                 .stream()
-                .map(PresentDto::from)
+                .map(PresentDto::of)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/depromeet/tifyapi/service/TagService.java
+++ b/src/main/java/com/depromeet/tifyapi/service/TagService.java
@@ -10,4 +10,6 @@ public interface TagService {
     List<TagDto> getTags();
     List<TagDto> getTagsByPostId(Integer postId);
     Integer createTag(TagDto tagDto);
+    Optional<TagDto> getTagByName(String name);
+    List<TagDto> getTagsIncludingName(String name);
 }

--- a/src/main/java/com/depromeet/tifyapi/service/TagServiceImpl.java
+++ b/src/main/java/com/depromeet/tifyapi/service/TagServiceImpl.java
@@ -27,7 +27,7 @@ public class TagServiceImpl implements TagService {
         return Optional.ofNullable(tagMapper.findAll())
                 .orElse(Collections.emptyList())
                 .stream()
-                .map(Tag::toTagDto)
+                .map(TagDto::of)
                 .collect(Collectors.toList());
     }
 
@@ -38,7 +38,7 @@ public class TagServiceImpl implements TagService {
             return Collections.emptyList();
         }
         return tags.stream()
-                .map(Tag::toTagDto)
+                .map(TagDto::of)
                 .collect(Collectors.toList());
     }
 
@@ -49,5 +49,20 @@ public class TagServiceImpl implements TagService {
             throw new NoContentException();
         }
         return tag.getTagId();
+    }
+
+    @Override
+    public Optional<TagDto> getTagByName(String name) {
+        return Optional.ofNullable(tagMapper.findTagByName(name))
+                .map(TagDto::of);
+    }
+
+    @Override
+    public List<TagDto> getTagsIncludingName(String name) {
+        return Optional.ofNullable(tagMapper.findTagsIncludingName(name))
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(TagDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/depromeet/tifyapi/service/TagServiceImpl.java
+++ b/src/main/java/com/depromeet/tifyapi/service/TagServiceImpl.java
@@ -33,11 +33,9 @@ public class TagServiceImpl implements TagService {
 
     @Override
     public List<TagDto> getTagsByPostId(Integer postId) {
-        List<Tag> tags = tagMapper.findTagsByPostId(postId);
-        if (tags == null) {
-            return Collections.emptyList();
-        }
-        return tags.stream()
+        return Optional.ofNullable(tagMapper.findTagsByPostId(postId))
+                .orElse(Collections.emptyList())
+                .stream()
                 .map(TagDto::of)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/depromeet/tifyapi/spring/ControllerAdvice.java
+++ b/src/main/java/com/depromeet/tifyapi/spring/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.depromeet.tifyapi.spring;
 
+import com.depromeet.tifyapi.Exception.BadRequestException;
 import com.depromeet.tifyapi.Exception.NoContentException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,11 @@ public class ControllerAdvice {
     @ExceptionHandler(value = DataAccessException.class)
     public ResponseEntity<String> handleDataAccessException(DataAccessException e) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(value = BadRequestException.class)
+    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/resources/com/depromeet/tifyapi/mapper/DescriptionMapper.xml
+++ b/src/main/resources/com/depromeet/tifyapi/mapper/DescriptionMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.depromeet.tifyapi.mapper.DescriptionMapper">
+    <resultMap id="resultMap" type="com.depromeet.tifyapi.model.Description">
+        <result column="tag_id" property="tagId" />
+        <result column="name" property="name" />
+    </resultMap>
+    <insert id="createDescription" parameterType="com.depromeet.tifyapi.model.Description">
+        INSERT INTO `description`
+        SET
+        post_id=#{description.postId},
+        tag_id=#{description.tagId}
+    </insert>
+</mapper>

--- a/src/main/resources/com/depromeet/tifyapi/mapper/TagMapper.xml
+++ b/src/main/resources/com/depromeet/tifyapi/mapper/TagMapper.xml
@@ -23,4 +23,14 @@
         FROM (SELECT tag_id FROM description where post_id = #{postId}) a
         join tag t on a.tag_id = t.tag_id;
     </select>
+    <select id="findTagByName" resultMap="resultMap">
+        SELECT *
+        FROM `tag`
+        WHERE tag.name = #{name}
+    </select>
+    <select id="findTagsIncludingName" resultMap="resultMap">
+        SELECT *
+        FROM `tag`
+        WHERE tag.name LIKE CONCAT('%',#{name},'%')
+    </select>
 </mapper>


### PR DESCRIPTION
- 기존의 `GET /tags` 요청을 `GET /tags?name={tag-name}&type={search-type}`으로 확장합니다. 
- Model class가 DTO class에 의존하는 코드를 삭제했습니다. 
- post에 tag를 추가하는 기능
- `GET /posts/{postId}/tags`
- `POST /posts/{postId}/tags`